### PR TITLE
CTP-6565 remove redundant import context_course

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -17,7 +17,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 use block_lifecycle\manager;
-use context_course;
 
 require_once($CFG->libdir . "/externallib.php");
 


### PR DESCRIPTION
This redundant import caused failures in Moodle full build automated tests. As externallib.php and context_course are both in global namespace, so no import is needed.